### PR TITLE
ci: add linting for cloudformation and gh workflows

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,11 +4,8 @@ on:
   pull_request:
 
 jobs:
-  unit-test:
+  test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src
 
     steps:
       - uses: actions/checkout@v3
@@ -18,27 +15,40 @@ jobs:
           node-version: 16
 
       - name: Install dependencies
-        run: yarn install
+        run: cd src && yarn install
 
       - name: Lint
-        run: yarn lint
+        run: cd src && yarn lint
 
       - name: Unit test
-        run: yarn test
+        run: cd src && yarn test
 
       - name: Rebuild the dist/ directory
-        run: yarn build
+        run: cd src && yarn build
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if [ "$(git diff --ignore-space-at-eol ../dist/ | wc -l)" -gt "0" ]; then
+          if [ "$(git diff --ignore-space-at-eol ./dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build within the ./dist directory"
             exit 1
           fi
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: CloudFormation Linter
+        run: |
+          pip install cfn-lint
+          shopt -s globstar # enable globbing
+          cfn-lint -t ./examples/*.yaml
+
+      - name: GitHub Workflow Linter
+        run: docker run --rm -v "$(pwd)":/repo --workdir /repo rhysd/actionlint:latest -color
+
   integration-test:
     runs-on: ubuntu-latest
-    needs: [ unit-test ]
+    needs: [ test ]
 
     permissions:
       id-token: write # required for OIDC

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ jobs:
 # TODO
 - [ ] setup release process - maybe manually initially?
 - [x] <strike>finish unit tests while learning jest</strike>
-- [ ] add cfn-lint to CloudFormation files in PR workflow
+- [x] add cfn-lint to CloudFormation files in PR workflow
 - [x] <strike>update docs to include all inputs. Good example https://github.com/actions/checkout#usage</strike>
 - [x] <strike>check for API responses in integration tests to validate both the action outputs and API infra is returning correct values</strike>
 - [x] <strike>list action in marketplace</strike> https://github.com/marketplace/actions/aws-api-gateway-request-with-oidc


### PR DESCRIPTION
Adds linting to CloudFormation files in the `examples` directory and all the GitHub Action workflow files.

Also updates the workflow job testing from `unit-test` to `test`. The branch protection required job name was also update.