### PR TITLE
feat: automate release versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - automate-releases
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
         env:
           MAJOR: ${{ steps.version.outputs.major-with-prefix }}
         run: |
-          git tag -d ${MAJOR} || true
-          git push origin :refs/tags/${MAJOR}
-          git tag ${MAJOR} ${GITHUB_SHA}
-          git push origin ${MAJOR}
+          git tag -d "${MAJOR}" || true
+          git push origin ":refs/tags/${MAJOR}"
+          git tag "${MAJOR}" "${GITHUB_SHA}"
+          git push origin "${MAJOR}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - automated-releases
+      - automate-releases
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+---
+name: release
+
+on:
+  push:
+    branches:
+      - main
+      - automated-releases
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: jveldboom/action-conventional-versioning@v1
+        id: version
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.version-with-prefix }}" \
+            --generate-notes \
+            --target "${{ github.sha }}"
+
+      - name: Update Major Tag
+        env:
+          MAJOR: ${{ steps.version.outputs.major-with-prefix }}
+        run: |
+          git tag -d ${MAJOR} || true
+          git push origin :refs/tags/${MAJOR}
+          git tag ${MAJOR} ${GITHUB_SHA}
+          git push origin ${MAJOR}

--- a/README.md
+++ b/README.md
@@ -91,12 +91,6 @@ jobs:
 ```
 
 # TODO
-- [ ] setup release process - maybe manually initially?
-- [x] <strike>finish unit tests while learning jest</strike>
-- [x] add cfn-lint to CloudFormation files in PR workflow
-- [x] <strike>update docs to include all inputs. Good example https://github.com/actions/checkout#usage</strike>
-- [x] <strike>check for API responses in integration tests to validate both the action outputs and API infra is returning correct values</strike>
-- [x] <strike>list action in marketplace</strike> https://github.com/marketplace/actions/aws-api-gateway-request-with-oidc
 - [ ] deploy example infrastructure on pushes to main
 
 # License


### PR DESCRIPTION
This change adds a new workflow that handles automatically creating the GH release as well as updating the floating major version (eg `v1`)