### PR TITLE
fix: minor clean up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
       interval: weekly
 
   - package-ecosystem: yarn
-    directory: /src
+    directory: /
     schedule:
       interval: weekly

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -33,7 +33,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: AWS API Gateway Request
         id: api-request
@@ -72,7 +72,7 @@ jobs:
           # max-retries: 3
 
       - name: Test API Response
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
 
         with:
           script: |

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,8 @@ jobs:
         run: |
           gh release create "${{ steps.version.outputs.version-with-prefix }}" \
             --generate-notes \
-            --target "${{ github.sha }}"
+            --notes-start-tag "${{ steps.version.outputs.previous-version-with-prefix }}"
+
 
       - name: Update Major Tag
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get next version
         uses: jveldboom/action-conventional-versioning@v1
@@ -26,7 +26,6 @@ jobs:
           gh release create "${{ steps.version.outputs.version-with-prefix }}" \
             --generate-notes \
             --notes-start-tag "${{ steps.version.outputs.previous-version-with-prefix }}"
-
 
       - name: Update Major Tag
         env:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 John Veldboom
+Copyright (c) 2026 John Veldboom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -90,8 +90,5 @@ jobs:
           echo "Body: ${{ steps.api-request.outputs.body }}"
 ```
 
-# TODO
-- [ ] deploy example infrastructure on pushes to main
-
 # License
 This action is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more information.

--- a/action.yaml
+++ b/action.yaml
@@ -49,9 +49,9 @@ runs:
         role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: ${{ inputs.aws-region }}
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 22
 
     - name: API Gateway request
       id: api-request

--- a/dist/index.js
+++ b/dist/index.js
@@ -7949,11 +7949,11 @@ const getHeadersFromInput = (headersInput = []) => {
   // loop through array of labels in [ 'key: value', 'key: value' ] format
   // split each array item to get the key and value to add to "labels" object
   for (const item of headersInput) {
-    const prop = item.split(':')
-    if (prop.length !== 2) continue
+    const colonIndex = item.indexOf(':')
+    if (colonIndex === -1) continue
 
-    const key = prop[0].trim()
-    const value = prop[1].trim()
+    const key = item.slice(0, colonIndex).trim()
+    const value = item.slice(colonIndex + 1).trim()
     if (key.length > 0 && value.length > 0) headers[key] = value
   }
 
@@ -7965,9 +7965,9 @@ const handleMainError = (err) => {
   if (err.response) {
     // The request was made and the server responded with a status code
     // that falls out of the range of 2xx
-    core.info('body', err.response.data)
-    core.info('status', err.response.status)
-    core.info('headers', err.response.headers)
+    core.info(`body: ${JSON.stringify(err.response.data)}`)
+    core.info(`status: ${err.response.status}`)
+    core.info(`headers: ${JSON.stringify(err.response.headers)}`)
     core.setFailed('request failed')
   } else if (err.request) {
     // The request was made but no response was received

--- a/dist/index.js
+++ b/dist/index.js
@@ -7967,7 +7967,6 @@ const handleMainError = (err) => {
     // that falls out of the range of 2xx
     core.info(`body: ${JSON.stringify(err.response.data)}`)
     core.info(`status: ${err.response.status}`)
-    core.info(`headers: ${JSON.stringify(err.response.headers)}`)
     core.setFailed('request failed')
   } else if (err.request) {
     // The request was made but no response was received

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "author": "John Veldboom",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "bugs": {
     "url": "https://github.com/jveldboom/action-aws-apigw-oidc-request/issues"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,7 +127,6 @@ const handleMainError = (err) => {
     // that falls out of the range of 2xx
     core.info(`body: ${JSON.stringify(err.response.data)}`)
     core.info(`status: ${err.response.status}`)
-    core.info(`headers: ${JSON.stringify(err.response.headers)}`)
     core.setFailed('request failed')
   } else if (err.request) {
     // The request was made but no response was received

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,11 +109,11 @@ const getHeadersFromInput = (headersInput = []) => {
   // loop through array of labels in [ 'key: value', 'key: value' ] format
   // split each array item to get the key and value to add to "labels" object
   for (const item of headersInput) {
-    const prop = item.split(':')
-    if (prop.length !== 2) continue
+    const colonIndex = item.indexOf(':')
+    if (colonIndex === -1) continue
 
-    const key = prop[0].trim()
-    const value = prop[1].trim()
+    const key = item.slice(0, colonIndex).trim()
+    const value = item.slice(colonIndex + 1).trim()
     if (key.length > 0 && value.length > 0) headers[key] = value
   }
 
@@ -125,9 +125,9 @@ const handleMainError = (err) => {
   if (err.response) {
     // The request was made and the server responded with a status code
     // that falls out of the range of 2xx
-    core.info('body', err.response.data)
-    core.info('status', err.response.status)
-    core.info('headers', err.response.headers)
+    core.info(`body: ${JSON.stringify(err.response.data)}`)
+    core.info(`status: ${err.response.status}`)
+    core.info(`headers: ${JSON.stringify(err.response.headers)}`)
     core.setFailed('request failed')
   } else if (err.request) {
     // The request was made but no response was received

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -179,6 +179,12 @@ describe('requests', () => {
       const expected = { foo: 'bar', 'x-cache-age': '10', padding: 'padding' }
       expect(utils.getHeadersFromInput(testArguments)).toStrictEqual(expected)
     })
+
+    it('should return header value with colons intact', () => {
+      const testArguments = ['authorization: Bearer token:value', 'x-date: Mon, 01 Jan 2024 00:00:00 GMT']
+      const expected = { authorization: 'Bearer token:value', 'x-date': 'Mon, 01 Jan 2024 00:00:00 GMT' }
+      expect(utils.getHeadersFromInput(testArguments)).toStrictEqual(expected)
+    })
   })
 
   describe('handleMainError()', () => {


### PR DESCRIPTION
## Summary
A handful of minor clean-up to get the project up-to-date.

- Fix `core.info()` calls in `handleMainError` that were swallowing error details (second argument was silently ignored)
- Fix bug in header parsing to split on first colon only, so header values containing colons (e.g. `Authorization: Bearer token:value`) are no longer dropped
- Fix `dependabot.yml` pointing to wrong directory so npm dependency updates are actually detected
- Bump GitHub Actions versions in workflows and update release workflow
